### PR TITLE
fix: accessor changes propagated to open pages

### DIFF
--- a/source/Injected/index.ts
+++ b/source/Injected/index.ts
@@ -52,7 +52,11 @@ let accessors: Accessors;
 sendMessage({destination: 'content', type: 'getAccessors', content: {}});
 window.addEventListener('message', (event: MessageEvent) => {
   const message = event.data;
-  if (message.app === EXTENSION_NAME && message.destination === 'injected') {
+  if (
+    message.app === EXTENSION_NAME &&
+    message.destination === 'injected' &&
+    message.type === 'accessors'
+  ) {
     accessors = message.content;
   }
 });
@@ -69,9 +73,7 @@ function getAllFields(object: JsObject, maxDepth = 7): JsObject {
       return JSON.parse(JSON.stringify(val));
     }
     if (typeof val === 'function') {
-      const result: {code: string; result?: JsValue; error?: string} = {
-        code: val.toString(),
-      };
+      const result: {result?: JsValue; error?: string} = {};
       if (val.length === 0 && key.startsWith('get')) {
         try {
           const f = val as () => JsValue;

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Ad Radar",
   "description": "An extension that shows you information about the ads you see online.",
-  "version": "1.0.1",
+  "version": "1.0.2",
 
   "icons": {
     "128": "assets/icons/color-128.png"


### PR DESCRIPTION
When saving accessor options, currently open pages immediately receive the new accessor values with no need to be reloaded.